### PR TITLE
remove recursive header includes

### DIFF
--- a/include/itkFastGrowCut.hxx
+++ b/include/itkFastGrowCut.hxx
@@ -19,7 +19,6 @@
 #ifndef itkFastGrowCut_hxx
 #define itkFastGrowCut_hxx
 
-#include "itkFastGrowCut.h"
 
 #include "itkPrintHelper.h"
 #include "itkImageMaskSpatialObject.h"

--- a/include/itkFastGrowCut.hxx
+++ b/include/itkFastGrowCut.hxx
@@ -310,7 +310,7 @@ FastGrowCut<TInputImage, TLabelImage, TMaskImage>::DijkstraBasedClassificationAH
         NodeIndexType    indexNgbh = index + m_NeighborIndexOffsets[i];
         NodeKeyValueType neighborCurrentDistance = distanceVolumePtr[indexNgbh];
         NodeKeyValueType neighborNewDistance =
-          fabs(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
+          itk::Math::abs(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
         if (neighborCurrentDistance > neighborNewDistance)
         {
           distanceVolumePtr[indexNgbh] = neighborNewDistance;
@@ -348,7 +348,7 @@ FastGrowCut<TInputImage, TLabelImage, TMaskImage>::DijkstraBasedClassificationAH
         NodeIndexType    indexNgbh = index + m_NeighborIndexOffsets[i];
         NodeKeyValueType neighborCurrentDistance = distanceVolumePtr[indexNgbh];
         NodeKeyValueType neighborNewDistance =
-          fabs(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
+          itk::Math::abs(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
         if (neighborCurrentDistance > neighborNewDistance)
         {
           distanceVolumePtr[indexNgbh] = neighborNewDistance;


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

