### PR TITLE
Compiler warning fixes

### DIFF
--- a/include/itkFastGrowCut.hxx
+++ b/include/itkFastGrowCut.hxx
@@ -291,7 +291,6 @@ FastGrowCut<TInputImage, TLabelImage, TMaskImage>::DijkstraBasedClassificationAH
   {
     // Full computation
     NodeKeyValueType * distanceVolumePtr = m_DistanceVolume->GetBufferPointer();
-    LabelPixelType *   resultLabelVolumePtr = resultLabelVolume->GetBufferPointer();
 
     // Normal Dijkstra (to be used in initializing the segmenter for the current image)
     while (!m_Heap->IsEmpty())

--- a/include/itkFastGrowCut.hxx
+++ b/include/itkFastGrowCut.hxx
@@ -372,12 +372,12 @@ void
 FastGrowCut<TInputImage, TLabelImage, TMaskImage>::GenerateData()
 {
   auto       inputImage = this->GetInput();
-  auto       seedImage = this->GetSeedImage();
+  // auto       seedImage = this->GetSeedImage();
   auto       outputImage = this->GetOutput();
   RegionType inRegion = inputImage->GetLargestPossibleRegion();
 
   SpacingType  spacing = inputImage->GetSpacing();
-  const double compareTolerance = (spacing[0] + spacing[1] + spacing[2]) / 3.0 * 0.01;
+  // const double compareTolerance = (spacing[0] + spacing[1] + spacing[2]) / 3.0 * 0.01;
 
   // Copy seedImage into the output
   RegionType region = outputImage->GetRequestedRegion();

--- a/include/itkFastGrowCut.hxx
+++ b/include/itkFastGrowCut.hxx
@@ -95,9 +95,9 @@ FastGrowCut<TInputImage, TLabelImage, TMaskImage>::InitializationAHP()
 
   RegionType region = resultLabelVolume->GetRequestedRegion();
 
-  NodeIndexType m_DimX = region.GetSize(0);
-  NodeIndexType m_DimY = region.GetSize(1);
-  NodeIndexType m_DimZ = region.GetSize(2);
+  m_DimX = region.GetSize(0);
+  m_DimY = region.GetSize(1);
+  m_DimZ = region.GetSize(2);
   NodeIndexType dimXYZ = m_DimX * m_DimY * m_DimZ;
 
   m_HeapNodes = new FibHeapNode[dimXYZ + 1]; // size is +1 for storing the zeroValueElement


### PR DESCRIPTION
This PR fixes #11 - the six compiler warnings. 

Each commit has references to the compiler warnings that they are resolving. 

For the third commit (COMP: Removed unused variables causing compiler warning.) The code was commented out instead of being deleted.

```
  auto       inputImage = this->GetInput();
  // auto       seedImage = this->GetSeedImage();
  auto       outputImage = this->GetOutput();
  RegionType inRegion = inputImage->GetLargestPossibleRegion();

  SpacingType  spacing = inputImage->GetSpacing();
  // const double compareTolerance = (spacing[0] + spacing[1] + spacing[2]) / 3.0 * 0.01;
```

 This was done because a comment block below references the variables. If preferred, I can remove both the comment block and the two variables entirely and update this PR. 
 
```
  // ImageAlgorithm::Copy(seedImage, outputImage, region, region);

  // These checks are done elsewhere in ITK pipeline:
  // if ((spacing - outputImage->GetSpacing()).GetNorm() > compareTolerance ||
  //     (inputImage->GetOrigin() - outputImage->GetOrigin()).GetNorm() > compareTolerance)
  // {
  //   // Restart growcut from scratch if image size is changed (then cached buffers cannot be reused)
  //   this->Reset();
  // }
```

Please let me know if you see any logic issues with the PR. 