### PR TITLE
ENH: Bump to v0.2.1 for ITK v5.4rc2

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,12 +4,12 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@246883ef3828fc00219145aeec9efa67b9889d0b
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@3f63de316255a285b0cac4c819d3d45649738999
     with:
       itk-cmake-options: '-DITK_BUILD_DEFAULT_MODULES:BOOL=OFF -DITKGroup_Core:BOOL=ON -DModule_ITKAntiAlias:BOOL=ON -DModule_ITKImageGrid:BOOL=ON -DModule_ITKSpatialObjects:BOOL=ON -DModule_ITKTestKernel:BOOL=ON -DModule_ITKMetaIO:BOOL=ON'
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@246883ef3828fc00219145aeec9efa67b9889d0b
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@3f63de316255a285b0cac4c819d3d45649738999
     with:
       test-notebooks: false
     secrets:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name='itk-growcut',
-    version='0.2.0',
+    version='0.2.1',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],
@@ -43,6 +43,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.3.0'
+        r'itk>=5.4rc2'
     ]
     )


### PR DESCRIPTION
Bump for ITK v5.4 release candidate 2 packages.

To follow release of v0.2.0 packages for ITk v5.3.0 compatibility: https://github.com/InsightSoftwareConsortium/ITKGrowCut/actions/runs/6879880624