### PR TITLE
ENH: Upgrade CI for ITK 5.4.0

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,12 +4,12 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@3f63de316255a285b0cac4c819d3d45649738999
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
     with:
       itk-cmake-options: '-DITK_BUILD_DEFAULT_MODULES:BOOL=OFF -DITKGroup_Core:BOOL=ON -DModule_ITKAntiAlias:BOOL=ON -DModule_ITKImageGrid:BOOL=ON -DModule_ITKSpatialObjects:BOOL=ON -DModule_ITKTestKernel:BOOL=ON -DModule_ITKMetaIO:BOOL=ON'
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@3f63de316255a285b0cac4c819d3d45649738999
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
     with:
       test-notebooks: false
     secrets:


### PR DESCRIPTION
Upgrade CI testing to use the latest ITK 5.4.0 version and CI configuration.

Committed via https://github.com/asottile/all-repos