### PR TITLE
COMP: Use modern macro for name of class

### DIFF
--- a/include/itkFastGrowCut.h
+++ b/include/itkFastGrowCut.h
@@ -69,7 +69,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods).  */
-  itkTypeMacro(FastGrowCut, ImageToImageFilter);
+   itkOverrideGetNameOfClassMacro(FastGrowCut);
 
   using InputImageType = TInputImage;
   using IntensityPixelType = typename InputImageType::PixelType;


### PR DESCRIPTION
When preparing for the future with ITK by setting
ITK_FUTURE_LEGACY_REMOVE:BOOL=ON
ITK_LEGACY_REMOVEBOOL=ON

The future preferred macro should be used
│ -  itkTypeMacro
│ +  itkOverrideGetNameOfClassMacro